### PR TITLE
Unordered map tests

### DIFF
--- a/tasks/tests/deque_test.cpp
+++ b/tasks/tests/deque_test.cpp
@@ -212,7 +212,16 @@ public:
     int x = 0;
 };
 
+struct NotCopyable {
+  NotCopyable() = default;
+  NotCopyable(const NotCopyable&) = delete;
+};
+
 void test6() {
+    {
+      Deque<NotCopyable> deq(10);
+    }
+
     Deque<NotDefaultConstructible> d;
     
     NotDefaultConstructible ndc = VerySpecialType(-1);

--- a/tasks/tests/unordered_map_test.cpp
+++ b/tasks/tests/unordered_map_test.cpp
@@ -197,6 +197,11 @@ namespace std {
 
 void TestNoRedundantCopies() {
 // std::cerr << "Test no redundant copies started" << std::endl;
+    {
+      UnorderedMap<NeitherDefaultNorCopyConstructible, int> m;
+      m[VerySpecialType(0)] = 0;
+    }
+
     UnorderedMap<NeitherDefaultNorCopyConstructible, NeitherDefaultNorCopyConstructible> m;
 // std::cerr << "m created" << std::endl;
     m.reserve(10);

--- a/tasks/tests/unordered_map_test.cpp
+++ b/tasks/tests/unordered_map_test.cpp
@@ -1,6 +1,7 @@
 #include "unordered_map.h"
 //#include <unordered_map>
 
+#include <tuple> // std::ignore
 #include <vector>
 #include <string>
 #include <iterator>
@@ -14,8 +15,16 @@
 using UnorderedMap = std::unordered_map<Key, Value, Hash, EqualTo, Alloc>;
 */
 
+void TestConstKey() {
+  UnorderedMap<int, int> m;
+  m[1] = 1;
+  assert(std::is_const_v<decltype(m.begin()->first)>);
+}
+
 void SimpleTest() {
     // std::cerr << "starting simple test" << std::endl;
+    TestConstKey();
+
     UnorderedMap<std::string, int> m;
 
     m["aaaaa"] = 5;


### PR DESCRIPTION
test for checking `operator[](Key&&)` does not copy key
and test if iterators point to std::pair with const Key